### PR TITLE
Fix repeat count not to be negative in history #195

### DIFF
--- a/internal/history.go
+++ b/internal/history.go
@@ -29,7 +29,10 @@ func History() {
 	fmt.Println(" ╭━━━━━━━━━━━━━━━━━━━╮")
 	for scanner.Scan() {
 		z := 14 - len(scanner.Text())
-		spaces := strings.Repeat(" ", z)
+		spaces := ""
+		if z >= 0 {
+		  spaces = strings.Repeat(" ", z)
+		}
 		if strings.Compare(string(scanner.Text()), "") == 0 {
 			continue
 		}


### PR DESCRIPTION
Fix #195 

I assumed that this insertion of spaces is to be something aligned.
But, conventionally It could be negative count when command length more than 14 characters.
https://golang.org/pkg/strings/#Repeat
`strings.Repeat` has occurred panic if count is negative.
So, this fix ignores space insertion when command length exceeds 14 chars.